### PR TITLE
printf logging fixed

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,7 +21,7 @@ workflows:
       # if you want to share this step into a StepLib
       - MY_STEPLIB_REPO_FORK_GIT_URL:
       - STEP_ID_IN_STEPLIB: sign-apk
-      - STEP_GIT_VERION_TAG_TO_SHARE: 0.9.2
+      - STEP_GIT_VERION_TAG_TO_SHARE: 0.9.3
       - STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-sign-apk.git
     description: |-
       If this is the first time you try to share a Step you should

--- a/step.sh
+++ b/step.sh
@@ -39,7 +39,7 @@ if [[ "${keystore_url}" == ${file_prefix}* ]] ; then
 	keystore_path=${keystore_url#$file_prefix}
 else
 	echo
-	printf "\e[34mDownloading keystore: \e[0m${keystore_url}\n"
+	printf "\e[34mDownloading keystore\e[0m\n"
 
 	tmp_dir=$(mktemp -d)
 	keystore_path="${tmp_dir}/keystore.jks"


### PR DESCRIPTION
fix for `invalid format character` when downloading keystore file