### PR TITLE
Added possibility to sign multiple APK files

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -28,7 +28,15 @@ inputs:
     opts:
       title: "apk path"
       summary: ""
-      description: ""
+      description: |-
+        Path(s) to the APK to sign.
+
+        You can provide multiple APK paths separated by `|` character.
+
+        Format examples:
+
+        - `/path/to/my/app.apk`
+        - `/path/to/my/app1.apk|/path/to/my/app2.apk|/path/to/my/app3.apk`
       is_required: true
   - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_URL
     opts:


### PR DESCRIPTION
I copied the functionality of the https://github.com/bitrise-steplib/steps-google-play-deploy step to this step because it is really useful.

In my project I get more than one APK file.
And with this change I can build the APK files and add them to the `BITRISE_APK_PATH`.
Then this step will sign all the specified APKs and then I can deploy all APKs with the google-play-deploy-step.

Without this change I must do everything twice.


**Before this change:**

    build-android:
      steps:
      - script:
          title: Build the app for distribution
          inputs:
          - content: |-
              #!/bin/bash
              set -ex
              # [...] Building [...]
              envman add --key BITRISE_APK_PATH_ARMV7 --value "./output/ARMv7.apk"
              envman add --key BITRISE_APK_PATH_X86 --value "./output/x86.apk"
      - sign-apk:
          title: Sign APK - ARMv7
          inputs:
          - apk_path: "$BITRISE_APK_PATH_ARMV7"
      - script:
          title: Move the signed ARMv7 apk to bitrise.io deploy folder
          inputs:
          - content: |-
              #!/bin/bash
              set -ex
              #
              mv "${BITRISE_APK_PATH}" "${BITRISE_DEPLOY_DIR}/armv7-Android.apk"
              envman add --key BITRISE_APK_PATH_ARMV7 --value "${BITRISE_DEPLOY_DIR}/armv7-Android.apk"
      - sign-apk:
          title: Sign APK - x86
          inputs:
          - apk_path: "$BITRISE_APK_PATH_X86"
      - script:
          title: Move the signed x86 apk to bitrise.io deploy folder
          inputs:
          - content: |-
              #!/bin/bash
              set -ex
              #
              mv "${BITRISE_APK_PATH}" "${BITRISE_DEPLOY_DIR}/x86-Android.apk"
              envman add --key BITRISE_APK_PATH_X86 --value "${BITRISE_DEPLOY_DIR}/x86-Android.apk"
      - google-play-deploy:
          inputs:
          - apk_path: "$BITRISE_APK_PATH_ARMV7|$BITRISE_APK_PATH_X86"

**And after this change really short.**

    build-android:
      steps:
      - script:
          title: Build the app for distribution
          inputs:
          - content: |-
              #!/bin/bash
              set -ex
              # [...] Building [...]
      - sign-apk:
          title: Sign APK files
          inputs:
          - apk_path: "$BITRISE_APK_PATH"
      - script:
          title: Copy the signed apk files to bitrise.io deploy folder
          inputs:
          - content: |-
              #!/bin/bash
              set -ex
              #
              (IFS="|"; cp ${BITRISE_APK_PATH} "${BITRISE_DEPLOY_DIR}")
      - google-play-deploy:
          inputs:
          - apk_path: "$BITRISE_APK_PATH"

Thank's in Advance for merge :+1: 


















**P.S.:**

I tested all possible scenarios. It will work with one APK as great as with multiple APKs.

    +------------------------------------------------------------------------------+
    | (2) Sign APKs                                                                |
    +------------------------------------------------------------------------------+
    | id: https://github.com/bussmann-it/steps-sign-apk.git                        |
    | version: master                                                              |
    | collection: git                                                              |
    | toolkit: go                                                                  |
    | time: 2017-05-13T18:41:33Z                                                   |
    +------------------------------------------------------------------------------+
    |                                                                              |
    INFO[18:41:33] Start installing (golang) with apt-get       
    INFO[18:41:33]  * [OK] Step dependency (go) installed, available. 
    
    Configs:
     - ApkPath: ./platforms/android/build/outputs/apk/android-armv7-release-unsigned.apk|./platforms/android/build/outputs/apk/android-x86-release-unsigned.apk
     - KeystoreURL: https://con***c42
     - KeystorePassword: ***
     - KeystoreAlias: KEYSTORE_ALIAS
     - PrivateKeyPassword: ***
     - JarsignerOptions: 
    
    Download keystore
    using keystore at: /tmp/bitrise-sign-apk062153598/keystore.jks
    
    android_home: /opt/android-sdk-linux
    aapt: /opt/android-sdk-linux/build-tools/25.0.3/aapt
    zipalign: /opt/android-sdk-linux/build-tools/25.0.3/zipalign
    
    No signature file (DSA or RSA) found in META-INF, skipping apk unsign...
    
    Sign APK
    => /usr/bin/jarsigner "-sigfile" "CERT" "-sigalg" "SHA1withDSA" "-digestalg" "SHA1" "-keystore" "/tmp/bitrise-sign-apk062153598/keystore.jks" "-storepass" "***" "-keypass" "***" "-signedjar" "/tmp/bitrise-sign-apk062153598/unaligned.apk" "/tmp/bitrise-sign-apk062153598/unsigned.apk" "KEYSTORE_ALIAS"
    signed
    
    Verify APK
    => /usr/bin/jarsigner "-verify" "-verbose" "-certs" "/tmp/bitrise-sign-apk062153598/unaligned.apk"
    verified
    
    Zipalign APK
    => /opt/android-sdk-linux/build-tools/25.0.3/zipalign "-f" "4" "/tmp/bitrise-sign-apk062153598/unaligned.apk" "platforms/android/build/outputs/apk/android-armv7-release-bitrise-signed.apk"
    zipaligned
    
    
    No signature file (DSA or RSA) found in META-INF, skipping apk unsign...
    
    Sign APK
    => /usr/bin/jarsigner "-sigfile" "CERT" "-sigalg" "SHA1withDSA" "-digestalg" "SHA1" "-keystore" "/tmp/bitrise-sign-apk062153598/keystore.jks" "-storepass" "***" "-keypass" "***" "-signedjar" "/tmp/bitrise-sign-apk062153598/unaligned.apk" "/tmp/bitrise-sign-apk062153598/unsigned.apk" "KEYSTORE_ALIAS"
    signed
    
    Verify APK
    => /usr/bin/jarsigner "-verify" "-verbose" "-certs" "/tmp/bitrise-sign-apk062153598/unaligned.apk"
    verified
    
    Zipalign APK
    => /opt/android-sdk-linux/build-tools/25.0.3/zipalign "-f" "4" "/tmp/bitrise-sign-apk062153598/unaligned.apk" "platforms/android/build/outputs/apk/android-x86-release-bitrise-signed.apk"
    zipaligned
    
    
    The Signed APK path is now available in the Environment Variable: BITRISE_SIGNED_APK_PATH (value: platforms/android/build/outputs/apk/android-armv7-release-bitrise-signed.apk|platforms/android/build/outputs/apk/android-x86-release-bitrise-signed.apk)
    The Signed APK path is now available in the Environment Variable: BITRISE_APK_PATH (value: platforms/android/build/outputs/apk/android-armv7-release-bitrise-signed.apk|platforms/android/build/outputs/apk/android-x86-release-bitrise-signed.apk)
    |                                                                              |
    +---+---------------------------------------------------------------+----------+
    | ✓ | Sign APKs                                                     | 17 sec   |
    +---+---------------------------------------------------------------+----------+

**And**

    ======= List of files =======
     * /bitrise/deploy/android-x86-release-bitrise-signed.apk
     * /bitrise/deploy/android-armv7-release-bitrise-signed.apk
    =============================
    
    
    
    # Deploying apk file: /bitrise/deploy/android-x86-release-bitrise-signed.apk
    --> Analyze the apk
      (i) apk_info_hsh: {:file_size_bytes=>32163938, :app_info=>{:app_name=>"Ionic Conference", :package_name=>"io.ionic.conferenceapp", :version_code=>"14", :version_name=>"0.0.1", :min_sdk_version=>"16"}}
    --> Create a Build Artifact on Bitrise
     (i) File Size: 30.67 MB
    --> Upload the apk
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
    100 30.6M    0     0  100 30.6M      0  27.2M  0:00:01  0:00:01 --:--:-- 27.1M
    100 30.6M    0     0  100 30.6M      0  27.1M  0:00:01  0:00:01 --:--:-- 27.1M
    --> Finish the Artifact creation
    
    
    # Deploying apk file: /bitrise/deploy/android-armv7-release-bitrise-signed.apk
    --> Analyze the apk
      (i) apk_info_hsh: {:file_size_bytes=>28302282, :app_info=>{:app_name=>"Ionic Conference", :package_name=>"io.ionic.conferenceapp", :version_code=>"12", :version_name=>"0.0.1", :min_sdk_version=>"16"}}
    --> Create a Build Artifact on Bitrise
     (i) File Size: 26.99 MB
    --> Upload the apk
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
     50 26.9M    0     0   50 13.5M      0  26.5M  0:00:01 --:--:--  0:00:01 26.5M
    100 26.9M    0     0  100 26.9M      0  23.1M  0:00:01  0:00:01 --:--:-- 23.1M
    --> Finish the Artifact creation

**And with only one APK file:**

    +------------------------------------------------------------------------------+
    | (2) Sign APKs                                                                |
    +------------------------------------------------------------------------------+
    | id: https://github.com/bussmann-it/steps-sign-apk.git                        |
    | version: master                                                              |
    | collection: git                                                              |
    | toolkit: go                                                                  |
    | time: 2017-05-13T17:52:57Z                                                   |
    +------------------------------------------------------------------------------+
    |                                                                              |
    INFO[17:52:57] Start installing (golang) with apt-get       
    INFO[17:52:57]  * [OK] Step dependency (go) installed, available. 
    
    Configs:
     - ApkPath: ./platforms/android/build/outputs/apk/android-x86-release-unsigned.apk
     - KeystoreURL: https://con***fd3
     - KeystorePassword: ***
     - KeystoreAlias: KEYSTORE_ALIAS
     - PrivateKeyPassword: ***
     - JarsignerOptions: 
    
    Download keystore
    using keystore at: /tmp/bitrise-sign-apk073539680/keystore.jks
    
    android_home: /opt/android-sdk-linux
    aapt: /opt/android-sdk-linux/build-tools/25.0.3/aapt
    zipalign: /opt/android-sdk-linux/build-tools/25.0.3/zipalign
    
    No signature file (DSA or RSA) found in META-INF, skipping apk unsign...
    
    Sign APK
    => /usr/bin/jarsigner "-sigfile" "CERT" "-sigalg" "SHA1withDSA" "-digestalg" "SHA1" "-keystore" "/tmp/bitrise-sign-apk073539680/keystore.jks" "-storepass" "***" "-keypass" "***" "-signedjar" "/tmp/bitrise-sign-apk073539680/unaligned.apk" "/tmp/bitrise-sign-apk073539680/unsigned.apk" "KEYSTORE_ALIAS"
    signed
    
    Verify APK
    => /usr/bin/jarsigner "-verify" "-verbose" "-certs" "/tmp/bitrise-sign-apk073539680/unaligned.apk"
    verified
    
    Zipalign APK
    => /opt/android-sdk-linux/build-tools/25.0.3/zipalign "-f" "4" "/tmp/bitrise-sign-apk073539680/unaligned.apk" "platforms/android/build/outputs/apk/android-x86-release-bitrise-signed.apk"
    zipaligned
    
    
    The Signed APK path is now available in the Environment Variable: BITRISE_SIGNED_APK_PATH (value: platforms/android/build/outputs/apk/android-x86-release-bitrise-signed.apk)
    The Signed APK path is now available in the Environment Variable: BITRISE_APK_PATH (value: platforms/android/build/outputs/apk/android-x86-release-bitrise-signed.apk)
    |                                                                              |
    +---+---------------------------------------------------------------+----------+
    | ✓ | Sign APKs                                                     | 13 sec   |
    +---+---------------------------------------------------------------+----------+

**And**

    ======= List of files =======
     * /bitrise/deploy/android-x86-release-bitrise-signed.apk
    =============================
    
    
    
    # Deploying apk file: /bitrise/deploy/android-x86-release-bitrise-signed.apk
    --> Analyze the apk
      (i) apk_info_hsh: {:file_size_bytes=>32163938, :app_info=>{:app_name=>"Ionic Conference", :package_name=>"io.ionic.conferenceapp", :version_code=>"14", :version_name=>"0.0.1", :min_sdk_version=>"16"}}
    --> Create a Build Artifact on Bitrise
     (i) File Size: 30.67 MB
    --> Upload the apk
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
     12 30.6M    0     0   12 4064k      0  5812k  0:00:05 --:--:--  0:00:05 5805k
    100 30.6M    0     0  100 30.6M      0  24.1M  0:00:01  0:00:01 --:--:-- 24.1M
    --> Finish the Artifact creation
