### PR TITLE
Fix Android App Bundle (.aab) signing.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -28,7 +28,7 @@ workflows:
     - errcheck:
     - go-test:
     after_run:
-    - test_apk
+    # - test_apk
     - test_bundle
 
   test_apk:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 5
+format_version: 6
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
@@ -8,8 +8,6 @@ app:
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-sign-apk.git
 
   - SAMPLE_APP_REPOSITORY_URL: https://github.com/bitrise-samples/sample-apps-android-abi-split.git
-  - BRANCH: master
-  - GRADLE_TASK: assembleRelease
   - GRADLEW_PATH: "./gradlew"
 
   # define these in your .bitrise.secrets.yml
@@ -24,63 +22,34 @@ workflows:
   ci:
     before_run:
     - audit-this-step
-    - _go_tests
-    - create_test_apk
     steps:
-    - path::./:
-        is_skippable: true
-        title: Step Test - keystore pass == key pass
-        inputs:
-        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_1_URL
-        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_1
-        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_1
-        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_1
-    - path::./:
-        is_skippable: true
-        title: Step Test - keystore pass != key pass
-        inputs:
-        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_2_URL
-        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_2
-        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_2
-        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_2
-    - path::./:
-        is_skippable: true
-        title: Step Test - default alias
-        inputs:
-        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_3_URL
-        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_3
-        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_3
-        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_3
-    - path::./:
-        is_skippable: true
-        title: Step Test - android studio generated keystore (jks)
-        inputs:
-        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_4_URL
-        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_4
-        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_4
-        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_4
+    - go-list:
+    - golint:
+    - errcheck:
+    - go-test:
+    after_run:
+    - test_apk
+    - test_bundle
 
-  test:
-    before_run:
-    - audit-this-step
-    - _go_tests
-    - create_test_apk
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            echo "BITRISE_APK_PATH: $BITRISE_APK_PATH" 
-    - path::./:
-        title: Step Test
-        inputs:
-        - apk_path: $BITRISE_APK_PATH_LIST
-    - script:
-        inputs:
-        - content: |-
-            echo "BITRISE_SIGNED_APK_PATH: $BITRISE_SIGNED_APK_PATH"
-            echo "BITRISE_APK_PATH: $BITRISE_APK_PATH" 
+  test_apk:
+    envs:
+    - BRANCH: master
+    - GRADLE_TASK: assembleRelease
+    - APK_FILE_INCLUDE_FILTER: "*.apk"
+    after_run:
+    - create_build_artifact
+    - test
+    
+  test_bundle:
+    envs:
+    - BRANCH: bundle_app
+    - GRADLE_TASK: bundleRelease
+    - APK_FILE_INCLUDE_FILTER: "*.aab"
+    after_run:
+    - create_build_artifact
+    - test
 
-  create_test_apk:
+  create_build_artifact:
     steps:
     - script:
         inputs:
@@ -116,6 +85,42 @@ workflows:
         inputs:
         - gradle_task: "$GRADLE_TASK"
         - gradlew_path: "$GRADLEW_PATH"
+        - apk_file_include_filter: $APK_FILE_INCLUDE_FILTER
+
+  test:
+    steps:
+    - path::./:
+        is_skippable: true
+        title: Step Test - keystore pass == key pass
+        inputs:
+        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_1_URL
+        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_1
+        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_1
+        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_1
+    - path::./:
+        is_skippable: true
+        title: Step Test - keystore pass != key pass
+        inputs:
+        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_2_URL
+        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_2
+        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_2
+        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_2
+    - path::./:
+        is_skippable: true
+        title: Step Test - default alias
+        inputs:
+        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_3_URL
+        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_3
+        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_3
+        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_3
+    - path::./:
+        is_skippable: true
+        title: Step Test - android studio generated keystore (jks)
+        inputs:
+        - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_4_URL
+        - keystore_password: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD_4
+        - keystore_alias: $BITRISEIO_ANDROID_KEYSTORE_ALIAS_4
+        - private_key_password: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_4
 
   _go_tests:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -83,7 +83,7 @@ workflows:
     - install-missing-android-tools@2.3.3:
         inputs:
         - ndk_revision: '16'
-        run_if ".IsCI"
+        run_if: ".IsCI"
     - gradle-runner:
         inputs:
         - gradle_task: "$GRADLE_TASK"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,6 +8,7 @@ app:
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-sign-apk.git
 
   - SAMPLE_APP_REPOSITORY_URL: https://github.com/bitrise-samples/sample-apps-android-abi-split.git
+  - BRANCH: master
   - GRADLEW_PATH: "./gradlew"
 
   # define these in your .bitrise.secrets.yml
@@ -28,12 +29,11 @@ workflows:
     - errcheck:
     - go-test:
     after_run:
-    # - test_apk
+    - test_apk
     - test_bundle
 
   test_apk:
     envs:
-    - BRANCH: master
     - GRADLE_TASK: assembleRelease
     - APK_FILE_INCLUDE_FILTER: "*.apk"
     after_run:
@@ -42,7 +42,6 @@ workflows:
     
   test_bundle:
     envs:
-    - BRANCH: bundle_app
     - GRADLE_TASK: bundleRelease
     - APK_FILE_INCLUDE_FILTER: "*.aab"
     after_run:
@@ -81,6 +80,10 @@ workflows:
             git remote add origin "${SAMPLE_APP_REPOSITORY_URL}"
             git fetch || exit 1
             [[ -n "${COMMIT}" ]] && git checkout "${COMMIT}" || git checkout "${BRANCH}"
+    - install-missing-android-tools@2.3.3:
+        inputs:
+        - ndk_revision: '16'
+        run_if ".IsCI"
     - gradle-runner:
         inputs:
         - gradle_task: "$GRADLE_TASK"

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -109,7 +109,7 @@ func NewHelper(keystorePth, keystorePassword, alias string) (Helper, error) {
 	}, nil
 }
 
-func (helper Helper) createSignCmd(apkPth, destApkPth, privateKeyPassword string) ([]string, error) {
+func (helper Helper) createSignCmd(buildArtifactPth, destBuildArtifactPth, privateKeyPassword string) ([]string, error) {
 	split := strings.Split(helper.signatureAlgorithm, "with")
 	if len(split) != 2 {
 		return []string{}, fmt.Errorf("failed to parse signature algorithm: %s", helper.signatureAlgorithm)
@@ -139,20 +139,20 @@ func (helper Helper) createSignCmd(apkPth, destApkPth, privateKeyPassword string
 		cmdSlice = append(cmdSlice, "-keypass", privateKeyPassword)
 	}
 
-	cmdSlice = append(cmdSlice, "-signedjar", destApkPth, apkPth, helper.alias)
+	cmdSlice = append(cmdSlice, "-signedjar", destBuildArtifactPth, buildArtifactPth, helper.alias)
 
 	return cmdSlice, nil
 }
 
-// SignAPK ...
-func (helper Helper) SignAPK(apkPth, destApkPth, privateKeyPassword string) error {
-	if exist, err := pathutil.IsPathExists(apkPth); err != nil {
+// SignBuildArtifact ...
+func (helper Helper) SignBuildArtifact(buildArtifactPth, destBuildArtifactPth, privateKeyPassword string) error {
+	if exist, err := pathutil.IsPathExists(buildArtifactPth); err != nil {
 		return err
 	} else if !exist {
-		return fmt.Errorf("APK not exist at: %s", apkPth)
+		return fmt.Errorf("Build Artifact not exist at: %s", buildArtifactPth)
 	}
 
-	cmdSlice, err := helper.createSignCmd(apkPth, destApkPth, privateKeyPassword)
+	cmdSlice, err := helper.createSignCmd(buildArtifactPth, destBuildArtifactPth, privateKeyPassword)
 	if err != nil {
 		return err
 	}
@@ -170,14 +170,14 @@ func (helper Helper) SignAPK(apkPth, destApkPth, privateKeyPassword string) erro
 	return nil
 }
 
-// VerifyAPK ...
-func (helper Helper) VerifyAPK(apkPth string) error {
+// VerifyBuildArtifact ...
+func (helper Helper) VerifyBuildArtifact(buildArtifactPth string) error {
 	cmdSlice := []string{
 		jarsigner,
 		"-verify",
 		"-verbose",
 		"-certs",
-		apkPth,
+		buildArtifactPth,
 	}
 
 	prinatableCmd := command.PrintableCommandArgs(false, cmdSlice)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var signingFileExts = []string{".mf", ".rsa", ".dsa", ".ec", ".sf"}
 
 // ConfigsModel ...
 type ConfigsModel struct {
-	ApkPath            string
+	BuildArtifactPath  string
 	KeystoreURL        string
 	KeystorePassword   string
 	KeystoreAlias      string
@@ -40,7 +40,7 @@ type ConfigsModel struct {
 
 func createConfigsModelFromEnvs() ConfigsModel {
 	return ConfigsModel{
-		ApkPath:            os.Getenv("apk_path"),
+		BuildArtifactPath:  os.Getenv("apk_path"),
 		KeystoreURL:        os.Getenv("keystore_url"),
 		KeystorePassword:   os.Getenv("keystore_password"),
 		KeystoreAlias:      os.Getenv("keystore_alias"),
@@ -52,7 +52,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 func (configs ConfigsModel) print() {
 	fmt.Println()
 	log.Infof("Configs:")
-	log.Printf(" - ApkPath: %s", configs.ApkPath)
+	log.Printf(" - ApkPath: %s", configs.BuildArtifactPath)
 	log.Printf(" - KeystoreURL: %s", secureInput(configs.KeystoreURL))
 	log.Printf(" - KeystorePassword: %s", secureInput(configs.KeystorePassword))
 	log.Printf(" - KeystoreAlias: %s", configs.KeystoreAlias)
@@ -63,11 +63,11 @@ func (configs ConfigsModel) print() {
 
 func (configs ConfigsModel) validate() error {
 	// required
-	if configs.ApkPath == "" {
+	if configs.BuildArtifactPath == "" {
 		return errors.New("no ApkPath parameter specified")
 	}
 
-	buildArtifactPaths := strings.Split(configs.ApkPath, "|")
+	buildArtifactPaths := strings.Split(configs.BuildArtifactPath, "|")
 	for _, buildArtifactPath := range buildArtifactPaths {
 		if exist, err := pathutil.IsPathExists(buildArtifactPath); err != nil {
 			return fmt.Errorf("failed to check if ApkPath exist at: %s, error: %s", buildArtifactPath, err)
@@ -342,7 +342,7 @@ func main() {
 	// ---
 
 	// Sign build artifacts
-	buildArtifactPaths := strings.Split(configs.ApkPath, "|")
+	buildArtifactPaths := strings.Split(configs.BuildArtifactPath, "|")
 	signedBuildArtifactPaths := make([]string, len(buildArtifactPaths))
 
 	log.Infof("signing %d Build Artifacts", len(buildArtifactPaths))

--- a/main_test.go
+++ b/main_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrettyAPKBasename(t *testing.T) {
-	require.Equal(t, "app", prettyAPKBasename("app-unsigned.apk"))
-	require.Equal(t, "app-signed", prettyAPKBasename("app-signed.apk"))
-	require.Equal(t, "app-debug", prettyAPKBasename("app-debug.apk"))
-	require.Equal(t, "app-release", prettyAPKBasename("app-release.apk"))
+func TestPrettyBuildArtifactBasename(t *testing.T) {
+	require.Equal(t, "app", prettyBuildArtifactBasename("app-unsigned.apk"))
+	require.Equal(t, "app-signed", prettyBuildArtifactBasename("app-signed.apk"))
+	require.Equal(t, "app-debug", prettyBuildArtifactBasename("app-debug.apk"))
+	require.Equal(t, "app-release", prettyBuildArtifactBasename("app-release.apk"))
 }
 
 func TestFilterMETAFiles(t *testing.T) {

--- a/step.yml
+++ b/step.yml
@@ -32,17 +32,20 @@ toolkit:
 inputs:
   - apk_path: "$BITRISE_APK_PATH"
     opts:
-      title: "apk path"
-      summary: ""
+      title: "Build artifact path."
+      summary: "`Android App Bundle (.aab)` or `Android Aplication Package (.apk)`"
       description: |-
-        Path(s) to the APK file to sign.
+        Path(s) to the build artifact file to sign (`.aab` or `.apk`).
 
-        You can provide multiple APK file paths separated by `|` character.
+        You can provide multiple build artifact file paths separated by `|` character.
 
         Format examples:
 
         - `/path/to/my/app.apk`
         - `/path/to/my/app1.apk|/path/to/my/app2.apk|/path/to/my/app3.apk`
+
+        - `/path/to/my/app.aab`
+        - `/path/to/my/app1.aab|/path/to/my/app2.apk|/path/to/my/app3.aab`
       is_required: true
   - keystore_url: $BITRISEIO_ANDROID_KEYSTORE_URL
     opts:
@@ -84,7 +87,7 @@ inputs:
 outputs:
 - BITRISE_SIGNED_APK_PATH:
   opts:
-    title: "Bitrise signed apk path"
+    title: "Bitrise signed build artifact path"
 - BITRISE_APK_PATH:
   opts:
-    title: "Bitrise signed apk path"
+    title: "Bitrise signed build artifact path"


### PR DESCRIPTION
Fix the bug, which overrode the exported signed build artifact's (`$BITRISE_SIGNED_APK_PATH`) extension to `.apk` even if it was a `.abb`. 