### PR TITLE
Optionally apply page align to APK

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ type configs struct {
 	OutputName         string `env:"output_name"`
 
 	VerboseLog bool `env:"verbose_log,opt[true,false]"`
+	PageAlign  bool `env:"page_align,opt[true,false]"`
 
 	// Deprecated
 	APKPath string `env:"apk_path"`

--- a/main.go
+++ b/main.go
@@ -238,9 +238,14 @@ func unsignBuildArtifact(aapt, pth string) error {
 	return removeFilesFromBuildArtifact(aapt, pth, signingFiles)
 }
 
-func zipalignBuildArtifact(zipalign, pth, dstPth string) error {
-	cmdSlice := []string{zipalign, "-f", "4", pth, dstPth}
+func zipalignBuildArtifact(zipalign, pth, dstPth string, pageAlign bool) error {
+	cmdSlice := []string{zipalign}
 
+	if pageAlign {
+		cmdSlice = append(cmdSlice, "-p")
+	}
+
+	cmdSlice = append(cmdSlice, "-f", "4", pth, dstPth)
 	prinatableCmd := command.PrintableCommandArgs(false, cmdSlice)
 	log.Printf("=> %s", prinatableCmd)
 
@@ -422,7 +427,7 @@ func main() {
 			signedAPKPaths = append(signedAPKPaths, fullPath)
 		}
 
-		if err := zipalignBuildArtifact(zipalign, unalignedBuildArtifactPth, fullPath); err != nil {
+		if err := zipalignBuildArtifact(zipalign, unalignedBuildArtifactPth, fullPath, cfg.PageAlign); err != nil {
 			failf("Failed to zipalign Build Artifact, error: %s", err)
 		}
 		fmt.Println()

--- a/step.yml
+++ b/step.yml
@@ -140,7 +140,7 @@ inputs:
       - "true"
       - "false"
       description: |
-        If enabled, teels zipalign to use memory page alignment for stored shared object files
+        If enabled, it tells zipalign to use memory page alignment for stored shared object files
   - output_name: ""
     opts:
       title: "Artifact name"

--- a/step.yml
+++ b/step.yml
@@ -130,6 +130,17 @@ inputs:
       summary: ""
       description: |
         __deprecated!__ jarsigner options are detected from the keystore
+  - page_align: "false"
+    opts:
+      title: "Page alignment"
+      summary: ""
+      is_sensitive: false
+      is_required: false
+      value_options:
+      - "true"
+      - "false"
+      description: |
+        If enabled, teels zipalign to use memory page alignment for stored shared object files
   - output_name: ""
     opts:
       title: "Artifact name"


### PR DESCRIPTION
### Related issue:

This PR aims to solve issues raised on #48 with the change requested on #36

### Abstract:

When using shared libraries with native development, the 4 byte alignment may present issues. Aiming to fix this issue, I added a variable to the test where the user can ask zip align to apply the same page alignment to all the dependencies.

Example of step configuration:

```yaml
- git::https://github.com/FutureWorkshops/steps-sign-apk@feature/zipalign_pagealign:
        inputs:
        - keystore_url: "$KEYSTORE_URL"
        - keystore_alias: "$KEYALIAS_PASSWORD"
        - keystore_password: "$KEYSTORE_PASSWORD"
        - private_key_password: "$KEYALIAS_PASSWORD"
        - android_app: "$BITRISE_APK_PATH_LIST"
        - page_align: 'true'
```

### Impact on existing code:

The added variable has its default value as `false`. So, users of the old version should see the same behaviour when using the new step version.

### Motivation:

When building an APK, I faced issues when installing the APK:

> E/NativeLibraryHelper: Library 'nice-native-lib.so' is not page-aligned - will not be able to open it directly from apk.

When studying a possible solution, I tough that applying the memory page alignment for stored shared object files instruction was the least intrusive way to correct it on Bitrise's step.