### PR TITLE
Remove signature with vanilla zip

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func filterMETAFiles(fileList []string) []string {
 }
 
 func filterSigningFiles(fileList []string) []string {
-	signingFiles := []string{}
+	var signingFiles []string
 	for _, file := range fileList {
 		ext := filepath.Ext(file)
 		for _, signExt := range signingFileExts {
@@ -155,8 +155,8 @@ func filterSigningFiles(fileList []string) []string {
 	return signingFiles
 }
 
-func removeFilesFromBuildArtifact(aapt, pth string, files []string) error {
-	cmdSlice := append([]string{aapt, "remove", pth}, files...)
+func removeFilesFromBuildArtifact(pth string, files []string) error {
+	cmdSlice := append([]string{"zip", "-d", pth}, files...)
 
 	prinatableCmd := command.PrintableCommandArgs(false, cmdSlice)
 	log.Printf("=> %s", prinatableCmd)
@@ -199,7 +199,7 @@ func unsignBuildArtifact(aapt, pth string) error {
 		return nil
 	}
 
-	return removeFilesFromBuildArtifact(aapt, pth, signingFiles)
+	return removeFilesFromBuildArtifact(pth, signingFiles)
 }
 
 func prettyBuildArtifactBasename(buildArtifactPth string) string {
@@ -357,7 +357,7 @@ func main() {
 			fullPath := signJarSigner(zipalign, tmpDir, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.PrivateKeyPassword, cfg.OutputName, keystore, pageAlignConfig)
 			signedAABPaths = append(signedAABPaths, fullPath)
 		} else if cfg.UseAPKSigner {
-			fullPath := signAPK(zipalign, tmpDir, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.OutputName, apkSigner, pageAlignConfig)
+			fullPath := signAPK(zipalign, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.OutputName, apkSigner, pageAlignConfig)
 			signedAPKPaths = append(signedAPKPaths, fullPath)
 		} else {
 			fullPath := signJarSigner(zipalign, tmpDir, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.PrivateKeyPassword, cfg.OutputName, keystore, pageAlignConfig)
@@ -414,7 +414,7 @@ func signJarSigner(zipalign, tmpDir string, unsignedBuildArtifactPth string, bui
 	return fullPath
 }
 
-func signAPK(zipalign, tmpDir string, unsignedBuildArtifactPth string, buildArtifactDir string, buildArtifactBasename string, artifactExt string, outputName string, apkSigner SignatureConfiguration, pageAlignConfig pageAlignStatus) string {
+func signAPK(zipalign, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, outputName string, apkSigner SignatureConfiguration, pageAlignConfig pageAlignStatus) string {
 	alignedPath, err := zipAlignArtifact(zipalign, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, "aligned", "", pageAlignConfig)
 	if err != nil {
 		failf("Failed to zipalign Build Artifact, error: %s", err)

--- a/step.yml
+++ b/step.yml
@@ -46,11 +46,8 @@ is_always_run: false
 is_skippable: false
 deps:
   brew:
-  - name: go
   - name: zip
   apt_get:
-  - name: golang
-    bin_name: go
   - name: zip
 toolkit:
   go:

--- a/step.yml
+++ b/step.yml
@@ -47,9 +47,11 @@ is_skippable: false
 deps:
   brew:
   - name: go
+  - name: zip
   apt_get:
   - name: golang
     bin_name: go
+  - name: zip
 toolkit:
   go:
     package_name: github.com/bitrise-steplib/steps-sign-apk


### PR DESCRIPTION
Use zip to remove items from apk as aapt seems to be generating corrupt zip files.

Test project: https://app.bitrise.io/app/864f8dcf926d2b55#/builds

[STEP-2]

[STEP-2]: https://bitrise.atlassian.net/browse/STEP-2