### PR TITLE
Return correct errors when parsing APK

### DIFF
--- a/apk_info.go
+++ b/apk_info.go
@@ -28,10 +28,10 @@ func parseAPKextractNativeLibs(apkPath string) (bool, error) {
 		return false, fmt.Errorf("failed to unzip the APK: %s", zipErr)
 	}
 	if resErr != nil {
-		return false, fmt.Errorf("failed to parse resources: %s", zipErr)
+		return false, fmt.Errorf("failed to parse resources: %s", resErr)
 	}
 	if manErr != nil {
-		return false, fmt.Errorf("failed to parse AndroidManifest.xml: %s", zipErr)
+		return false, fmt.Errorf("failed to parse AndroidManifest.xml: %s", manErr)
 	}
 
 	var manifest manifest


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

I noticed that the errors being returned when parsing the APK in this Step were all returning just one of the error types. Probably just a copypasta mixup.

### Changes

- Updates `apk_info.go` to return the correct error types when parsing APKs