### PR TITLE
Remove apk_path required status

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -170,7 +170,6 @@ inputs:
 
       - `/path/to/my/app.aab`
       - `/path/to/my/app1.aab|/path/to/my/app2.apk|/path/to/my/app3.aab`
-    is_required: true
 outputs:
 - BITRISE_SIGNED_APK_PATH:
   opts:


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

When the `apk_path` field was deprecated its required status was removed from the code:
https://github.com/bitrise-steplib/steps-sign-apk/blob/1c3621a73b1d501cfb3db9174ce7b21eb3576f4b/main.go#L44

But unfortunately it was left in the `step.yml` file which is confusing to the user. This PR will remove that required status so the workflow editor will present accurate information.
