### PR TITLE
Replace use_apk_signer with signer_tool step input

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -6,6 +6,7 @@ app:
   - TEST_APP_REPO: https://github.com/bitrise-io/sample-apps-android-abi-split.git
   - TEST_APP_BRANCH: master
   - TEST_APP_GRADLE_WRAPPER_PATH: ./gradlew
+  - SIGNER_TOOL: automatic
   # define these in your .bitrise.secrets.yml
   # Keystore password == key password
   - SAME_PASS_ANDROID_KEYSTORE_URL: $SAME_PASS_ANDROID_KEYSTORE_URL
@@ -29,115 +30,29 @@ app:
   - STUDIO_GEN_ANDROID_KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
 
 workflows:
-  test_apk:
+  test_apk_signing:
     envs:
     - TEST_APP_GRADLE_TASK: assembleRelease
     - APK_FILE_INCLUDE_FILTER: "*.apk"
     after_run:
-    - _run_collection
+    - _build_app_and_sign_with_keystore_combinations
 
   # Using apksigner zipalign fails to zipalign already zipaligned artifact
-  test_apk_debug:
+  test_debug_apk_signing:
     envs:
     - TEST_APP_GRADLE_TASK: assembleDebug
     - APK_FILE_INCLUDE_FILTER: "*.apk"
     after_run:
-    - _run_collection
+    - _build_app_and_sign_with_keystore_combinations
 
-  test_bundle:
+  test_app_bundle_signing:
     envs:
     - TEST_APP_GRADLE_TASK: bundleRelease
     - APK_FILE_INCLUDE_FILTER: "*.aab"
     after_run:
-    - _run_collection
+    - _build_app_and_sign_with_keystore_combinations
 
-  utility_test_same_pass:
-    title: Step Test - keystore pass == key pass
-    envs:
-    - KEYSTORE_URL: $SAME_PASS_ANDROID_KEYSTORE_URL
-    - KEYSTORE_PASSWORD: $SAME_PASS_ANDROID_KEYSTORE_PASSWORD
-    - KEYSTORE_ALIAS: $SAME_PASS_ANDROID_KEY_ALIAS
-    - KEY_PASSWORD: $SAME_PASS_ANDROID_KEY_PASSWORD
-    after_run:
-    - _run
-
-  utility_test_diff_pass:
-    title: Step Test - keystore pass != key pass
-    envs:
-    - KEYSTORE_URL: $DIFF_PASS_ANDROID_KEYSTORE_URL
-    - KEYSTORE_PASSWORD: $DIFF_PASS_ANDROID_KEYSTORE_PASSWORD
-    - KEYSTORE_ALIAS: $DIFF_PASS_ANDROID_KEY_ALIAS
-    - KEY_PASSWORD: $DIFF_PASS_ANDROID_KEY_PASSWORD
-    after_run:
-    - _run
-
-  utility_test_default_alias:
-    title: Step Test - default alias
-    envs:
-    - KEYSTORE_URL: $DEFAULT_ALIAS_ANDROID_KEYSTORE_URL
-    - KEYSTORE_PASSWORD: $DEFAULT_ALIAS_ANDROID_KEYSTORE_PASSWORD
-    - KEYSTORE_ALIAS: $DEFAULT_ALIAS_ANDROID_KEY_ALIAS
-    - KEY_PASSWORD: $DEFAULT_ALIAS_ANDROID_KEY_PASSWORD
-    after_run:
-    - _run
-
-  utility_test_studio_gen_keystore:
-    title: Step Test - android studio generated keystore (jks)
-    envs:
-    - KEYSTORE_URL: $STUDIO_GEN_ANDROID_KEYSTORE_URL
-    - KEYSTORE_PASSWORD: $STUDIO_GEN_ANDROID_KEYSTORE_PASSWORD
-    - KEYSTORE_ALIAS: $STUDIO_GEN_ANDROID_KEY_ALIAS
-    - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
-    after_run:
-    - _run
-
-  utility_test_custom_artifact_name:
-    title: Step Test - android studio generated keystore (jks) + custom artifact name
-    envs:
-    - KEYSTORE_URL: $STUDIO_GEN_ANDROID_KEYSTORE_URL
-    - KEYSTORE_PASSWORD: $STUDIO_GEN_ANDROID_KEYSTORE_PASSWORD
-    - KEYSTORE_ALIAS: $STUDIO_GEN_ANDROID_KEY_ALIAS
-    - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
-    - OUTPUT_NAME: test-artifact-name
-    after_run:
-    - _run
-    - utility_test_custom_artifact_name_again
-
-  utility_test_custom_artifact_name_again:
-    title: Step Test - android studio generated keystore (jks) + custom artifact name second time to see collisions if any
-    envs:
-    - KEYSTORE_URL: $STUDIO_GEN_ANDROID_KEYSTORE_URL
-    - KEYSTORE_PASSWORD: $STUDIO_GEN_ANDROID_KEYSTORE_PASSWORD
-    - KEYSTORE_ALIAS: $STUDIO_GEN_ANDROID_KEY_ALIAS
-    - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
-    - OUTPUT_NAME: test-artifact-name
-    after_run:
-    - _run
-
-  _run:
-    steps:
-    - set-java-version:
-        inputs:
-        - set_java_version: 17
-    - script:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-            if [ -n "$ORIG_BITRISE_APK_PATH" ]; then
-              envman add --key BITRISE_APK_PATH --value ${ORIG_BITRISE_APK_PATH}
-            fi
-    - path::./:
-        title: Step Test - android studio generated keystore (jks) + custom artifact name
-        inputs:
-        - keystore_url: $KEYSTORE_URL
-        - keystore_password: $KEYSTORE_PASSWORD
-        - keystore_alias: $KEYSTORE_ALIAS
-        - private_key_password: $KEY_PASSWORD
-        - output_name: $OUTPUT_NAME
-        - use_apk_signer: $APK_SIGNER
-
-  _run_collection:
+  _build_app_and_sign_with_keystore_combinations:
     steps:
     - set-java-version:
         inputs:
@@ -184,9 +99,10 @@ workflows:
               envman add --key ORIG_BITRISE_APK_PATH --value ${BITRISE_APK_PATH}
             fi
     after_run:
-    - _jarsigner_all_tests
-    - _apksigner_all_tests
-  _jarsigner_all_tests:
+    - _sign_with_jarsigner_with_keystore_combinations
+    - _sign_with_apksigner_with_keystore_combinations
+
+  _sign_with_jarsigner_with_keystore_combinations:
     steps:
     - script:
         inputs:
@@ -196,7 +112,7 @@ workflows:
     after_run:
     - _all_keystore_tests
 
-  _apksigner_all_tests:
+  _sign_with_apksigner_with_keystore_combinations:
     steps:
     - script:
         inputs:
@@ -208,8 +124,94 @@ workflows:
 
   _all_keystore_tests:
     after_run:
-    - utility_test_same_pass
-    - utility_test_diff_pass
-    - utility_test_default_alias
-    - utility_test_studio_gen_keystore
-    - utility_test_custom_artifact_name
+    - _sign_with_keystore_with_same_pass
+    - _sign_with_keystore_with_diff_pass
+    - _sign_with_keystore_with_default_alias
+    - _sign_with_studio_gen_keystore
+    - _sign_with_custom_artifact_name
+
+  _sign_with_keystore_with_same_pass:
+    title: Step Test - keystore pass == key pass
+    envs:
+    - KEYSTORE_URL: $SAME_PASS_ANDROID_KEYSTORE_URL
+    - KEYSTORE_PASSWORD: $SAME_PASS_ANDROID_KEYSTORE_PASSWORD
+    - KEYSTORE_ALIAS: $SAME_PASS_ANDROID_KEY_ALIAS
+    - KEY_PASSWORD: $SAME_PASS_ANDROID_KEY_PASSWORD
+    after_run:
+    - _sign_app
+
+  _sign_with_keystore_with_diff_pass:
+    title: Step Test - keystore pass != key pass
+    envs:
+    - KEYSTORE_URL: $DIFF_PASS_ANDROID_KEYSTORE_URL
+    - KEYSTORE_PASSWORD: $DIFF_PASS_ANDROID_KEYSTORE_PASSWORD
+    - KEYSTORE_ALIAS: $DIFF_PASS_ANDROID_KEY_ALIAS
+    - KEY_PASSWORD: $DIFF_PASS_ANDROID_KEY_PASSWORD
+    after_run:
+    - _sign_app
+
+  _sign_with_keystore_with_default_alias:
+    title: Step Test - default alias
+    envs:
+    - KEYSTORE_URL: $DEFAULT_ALIAS_ANDROID_KEYSTORE_URL
+    - KEYSTORE_PASSWORD: $DEFAULT_ALIAS_ANDROID_KEYSTORE_PASSWORD
+    - KEYSTORE_ALIAS: $DEFAULT_ALIAS_ANDROID_KEY_ALIAS
+    - KEY_PASSWORD: $DEFAULT_ALIAS_ANDROID_KEY_PASSWORD
+    after_run:
+    - _sign_app
+
+  _sign_with_studio_gen_keystore:
+    title: Step Test - android studio generated keystore (jks)
+    envs:
+    - KEYSTORE_URL: $STUDIO_GEN_ANDROID_KEYSTORE_URL
+    - KEYSTORE_PASSWORD: $STUDIO_GEN_ANDROID_KEYSTORE_PASSWORD
+    - KEYSTORE_ALIAS: $STUDIO_GEN_ANDROID_KEY_ALIAS
+    - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
+    after_run:
+    - _sign_app
+
+  _sign_with_custom_artifact_name:
+    title: Step Test - android studio generated keystore (jks) + custom artifact name
+    envs:
+    - KEYSTORE_URL: $STUDIO_GEN_ANDROID_KEYSTORE_URL
+    - KEYSTORE_PASSWORD: $STUDIO_GEN_ANDROID_KEYSTORE_PASSWORD
+    - KEYSTORE_ALIAS: $STUDIO_GEN_ANDROID_KEY_ALIAS
+    - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
+    - OUTPUT_NAME: test-artifact-name
+    after_run:
+    - _sign_app
+    - _sign_with_custom_artifact_name_again
+
+  _sign_with_custom_artifact_name_again:
+    title: Step Test - android studio generated keystore (jks) + custom artifact name second time to see collisions if any
+    envs:
+    - KEYSTORE_URL: $STUDIO_GEN_ANDROID_KEYSTORE_URL
+    - KEYSTORE_PASSWORD: $STUDIO_GEN_ANDROID_KEYSTORE_PASSWORD
+    - KEYSTORE_ALIAS: $STUDIO_GEN_ANDROID_KEY_ALIAS
+    - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
+    - OUTPUT_NAME: test-artifact-name
+    after_run:
+    - _sign_app
+
+  _sign_app:
+    steps:
+    - set-java-version:
+        inputs:
+        - set_java_version: 17
+    - script:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            if [ -n "$ORIG_BITRISE_APK_PATH" ]; then
+              envman add --key BITRISE_APK_PATH --value ${ORIG_BITRISE_APK_PATH}
+            fi
+    - path::./:
+        title: Step Test - android studio generated keystore (jks) + custom artifact name
+        inputs:
+        - keystore_url: $KEYSTORE_URL
+        - keystore_password: $KEYSTORE_PASSWORD
+        - keystore_alias: $KEYSTORE_ALIAS
+        - private_key_password: $KEY_PASSWORD
+        - output_name: $OUTPUT_NAME
+        - signer_tool: $SIGNER_TOOL

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -106,7 +106,7 @@ workflows:
     - _sign_with_custom_artifact_name
 
   _sign_with_jarsigner_with_keystore_with_same_pass:
-    title: Step Test - keystore pass == key pass
+    title: Step Test - keystore pass == key pass - jarsigner
     envs:
     - KEYSTORE_URL: $SAME_PASS_ANDROID_KEYSTORE_URL
     - KEYSTORE_PASSWORD: $SAME_PASS_ANDROID_KEYSTORE_PASSWORD
@@ -117,7 +117,7 @@ workflows:
     - _sign_app
 
   _sign_with_apksigner_with_keystore_with_diff_pass:
-    title: Step Test - keystore pass != key pass
+    title: Step Test - keystore pass != key pass - apksigner for APK files
     envs:
     - KEYSTORE_URL: $DIFF_PASS_ANDROID_KEYSTORE_URL
     - KEYSTORE_PASSWORD: $DIFF_PASS_ANDROID_KEYSTORE_PASSWORD

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -6,7 +6,7 @@ app:
   - TEST_APP_REPO: https://github.com/bitrise-io/sample-apps-android-abi-split.git
   - TEST_APP_BRANCH: master
   - TEST_APP_GRADLE_WRAPPER_PATH: ./gradlew
-  - SIGNER_TOOL: automatic
+  - ORIG_SIGNER_TOOL: automatic
   # define these in your .bitrise.secrets.yml
   # Keystore password == key password
   - SAME_PASS_ANDROID_KEYSTORE_URL: $SAME_PASS_ANDROID_KEYSTORE_URL
@@ -114,7 +114,9 @@ workflows:
     - KEY_PASSWORD: $SAME_PASS_ANDROID_KEY_PASSWORD
     - SIGNER_TOOL: jarsigner
     after_run:
+    - _setup_signer_tool_env_var
     - _sign_app
+    - _reset_signer_tool_env_var
 
   _sign_with_apksigner_with_keystore_with_diff_pass:
     title: Step Test - keystore pass != key pass - apksigner for APK files
@@ -133,7 +135,9 @@ workflows:
               envman add --key SIGNER_TOOL --value "apksigner"
             fi
     after_run:
+    - _setup_signer_tool_env_var
     - _sign_app
+    - _reset_signer_tool_env_var
 
   _sign_with_keystore_with_default_alias:
     title: Step Test - default alias
@@ -143,7 +147,9 @@ workflows:
     - KEYSTORE_ALIAS: $DEFAULT_ALIAS_ANDROID_KEY_ALIAS
     - KEY_PASSWORD: $DEFAULT_ALIAS_ANDROID_KEY_PASSWORD
     after_run:
+    - _setup_signer_tool_env_var
     - _sign_app
+    - _reset_signer_tool_env_var
 
   _sign_with_studio_gen_keystore:
     title: Step Test - android studio generated keystore (jks)
@@ -153,7 +159,9 @@ workflows:
     - KEYSTORE_ALIAS: $STUDIO_GEN_ANDROID_KEY_ALIAS
     - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
     after_run:
+    - _setup_signer_tool_env_var
     - _sign_app
+    - _reset_signer_tool_env_var
 
   _sign_with_custom_artifact_name:
     title: Step Test - android studio generated keystore (jks) + custom artifact name
@@ -164,8 +172,10 @@ workflows:
     - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
     - OUTPUT_NAME: test-artifact-name
     after_run:
+    - _setup_signer_tool_env_var
     - _sign_app
     - _sign_with_custom_artifact_name_again
+    - _reset_signer_tool_env_var
 
   _sign_with_custom_artifact_name_again:
     title: Step Test - android studio generated keystore (jks) + custom artifact name second time to see collisions if any
@@ -176,7 +186,9 @@ workflows:
     - KEY_PASSWORD: $STUDIO_GEN_ANDROID_KEY_PASSWORD
     - OUTPUT_NAME: test-artifact-name
     after_run:
+    - _setup_signer_tool_env_var
     - _sign_app
+    - _reset_signer_tool_env_var
 
   _sign_app:
     steps:
@@ -200,3 +212,23 @@ workflows:
         - private_key_password: $KEY_PASSWORD
         - output_name: $OUTPUT_NAME
         - signer_tool: $SIGNER_TOOL
+
+  _setup_signer_tool_env_var:
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            if [ -z "$SIGNER_TOOL" ]; then
+              envman add --key SIGNER_TOOL --value "$ORIG_SIGNER_TOOL"
+            fi
+
+  _reset_signer_tool_env_var:
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            envman unset --key SIGNER_TOOL

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -99,54 +99,39 @@ workflows:
               envman add --key ORIG_BITRISE_APK_PATH --value ${BITRISE_APK_PATH}
             fi
     after_run:
-    - _sign_with_jarsigner_with_keystore_combinations
-    - _sign_with_apksigner_with_keystore_combinations
-
-  _sign_with_jarsigner_with_keystore_combinations:
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            echo "jarsigner"
-            envman add --key APK_SIGNER --value "false"
-    after_run:
-    - _all_keystore_tests
-
-  _sign_with_apksigner_with_keystore_combinations:
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            echo "apksigner"
-            envman add --key APK_SIGNER --value "true"
-    after_run:
-    - _all_keystore_tests
-
-  _all_keystore_tests:
-    after_run:
-    - _sign_with_keystore_with_same_pass
-    - _sign_with_keystore_with_diff_pass
+    - _sign_with_jarsigner_with_keystore_with_same_pass
+    - _sign_with_apksigner_with_keystore_with_diff_pass
     - _sign_with_keystore_with_default_alias
     - _sign_with_studio_gen_keystore
     - _sign_with_custom_artifact_name
 
-  _sign_with_keystore_with_same_pass:
+  _sign_with_jarsigner_with_keystore_with_same_pass:
     title: Step Test - keystore pass == key pass
     envs:
     - KEYSTORE_URL: $SAME_PASS_ANDROID_KEYSTORE_URL
     - KEYSTORE_PASSWORD: $SAME_PASS_ANDROID_KEYSTORE_PASSWORD
     - KEYSTORE_ALIAS: $SAME_PASS_ANDROID_KEY_ALIAS
     - KEY_PASSWORD: $SAME_PASS_ANDROID_KEY_PASSWORD
+    - SIGNER_TOOL: jarsigner
     after_run:
     - _sign_app
 
-  _sign_with_keystore_with_diff_pass:
+  _sign_with_apksigner_with_keystore_with_diff_pass:
     title: Step Test - keystore pass != key pass
     envs:
     - KEYSTORE_URL: $DIFF_PASS_ANDROID_KEYSTORE_URL
     - KEYSTORE_PASSWORD: $DIFF_PASS_ANDROID_KEYSTORE_PASSWORD
     - KEYSTORE_ALIAS: $DIFF_PASS_ANDROID_KEY_ALIAS
     - KEY_PASSWORD: $DIFF_PASS_ANDROID_KEY_PASSWORD
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            if [ -z "$BITRISE_AAB_PATH" ]; then
+              envman add --key SIGNER_TOOL --value "apksigner"
+            fi
     after_run:
     - _sign_app
 

--- a/main.go
+++ b/main.go
@@ -239,7 +239,8 @@ func validate(cfg configs) error {
 			return fmt.Errorf("BuildArtifactPath not exist at: %s", buildArtifactPath)
 		}
 
-		signAAB := strings.EqualFold(buildArtifactPath, ".aab")
+		artifactExt := path.Ext(buildArtifactPath)
+		signAAB := strings.EqualFold(artifactExt, ".aab")
 		if cfg.SignerTool == "apksigner" && signAAB {
 			failf("signer tool apksigner does not support signing AABs, please use automatic or jarsigner instead")
 		}

--- a/main.go
+++ b/main.go
@@ -38,11 +38,19 @@ type configs struct {
 	PageAlign           string `env:"page_align,opt[automatic,true,false]"`
 	SignerScheme        string `env:"signer_scheme,opt[automatic,v2,v3,v4]"`
 	DebuggablePermitted string `env:"debuggable_permitted,opt[true,false]"`
-	UseAPKSigner        bool   `env:"use_apk_signer,opt[true,false]"`
+	SignerTool          string `env:"signer_tool,opt[automatic,apksigner,jarsigner]"`
 
 	// Deprecated
 	APKPath string `env:"apk_path"`
 }
+
+type codeSignerTool string
+
+const (
+	apksignerSignerTool codeSignerTool = "apksigner"
+	jarsignerSignerTool codeSignerTool = "jarsigner"
+	automaticSignerTool codeSignerTool = "automatic"
+)
 
 type pageAlignStatus int
 
@@ -230,6 +238,11 @@ func validate(cfg configs) error {
 		} else if !exist {
 			return fmt.Errorf("BuildArtifactPath not exist at: %s", buildArtifactPath)
 		}
+
+		signAAB := strings.EqualFold(buildArtifactPath, ".aab")
+		if cfg.SignerTool == "apksigner" && signAAB {
+			failf("signer tool apksigner does not support signing AABs, please use automatic or jarsigner instead")
+		}
 	}
 	return nil
 }
@@ -338,8 +351,16 @@ func main() {
 		}
 
 		signAAB := strings.EqualFold(artifactExt, ".aab")
+		signerTool := cfg.SignerTool
+		if signerTool == string(automaticSignerTool) {
+			if signAAB {
+				signerTool = string(jarsignerSignerTool)
+			} else {
+				signerTool = string(apksignerSignerTool)
+			}
+		}
 
-		if signAAB || !cfg.UseAPKSigner {
+		if signerTool == string(jarsignerSignerTool) {
 			isSigned, err := isBuildArtifactSigned(aapt, unsignedBuildArtifactPth)
 			if err != nil {
 				failf("Run: failed to check if build artifact is signed: %s", err)
@@ -359,14 +380,16 @@ func main() {
 			log.Printf("Skipping removal of existing signature as apksigner can re-sign already signed apk.")
 		}
 
-		if signAAB {
-			fullPath := signJarSigner(zipalign, tmpDir, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.PrivateKeyPassword, cfg.OutputName, keystore, pageAlignConfig)
-			signedAABPaths = append(signedAABPaths, fullPath)
-		} else if cfg.UseAPKSigner {
-			fullPath := signAPK(zipalign, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.OutputName, apkSigner, pageAlignConfig)
-			signedAPKPaths = append(signedAPKPaths, fullPath)
+		var fullPath string
+		if signerTool == string(apksignerSignerTool) {
+			fullPath = signAPK(zipalign, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.OutputName, apkSigner, pageAlignConfig)
 		} else {
-			fullPath := signJarSigner(zipalign, tmpDir, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.PrivateKeyPassword, cfg.OutputName, keystore, pageAlignConfig)
+			fullPath = signJarSigner(zipalign, tmpDir, unsignedBuildArtifactPth, buildArtifactDir, buildArtifactBasename, artifactExt, cfg.PrivateKeyPassword, cfg.OutputName, keystore, pageAlignConfig)
+		}
+
+		if signAAB {
+			signedAABPaths = append(signedAABPaths, fullPath)
+		} else {
 			signedAPKPaths = append(signedAPKPaths, fullPath)
 		}
 

--- a/step.yml
+++ b/step.yml
@@ -103,14 +103,20 @@ inputs:
       - `automatic`: Enable page alignment for .so files, unless atribute `extractNativeLibs="true"` is set in the AndroidManifest.xml
       - `true`: Enable memory page alignment for .so files
       - `false`: Disable memory page alignment for .so files
-- use_apk_signer: "false"
+- signer_tool: automatic
   opts:
-    title: Enables apksigner
-    description: Indicates if the signature should be done using `apksigner` instead of `jarsigner`.
+    title: Signer tool
     is_required: true
     value_options:
-    - "true"
-    - "false"
+    - automatic
+    - apksigner
+    - jarsigner
+    description: |
+      Indicates which tool should be used for signing the app.
+
+      - `automatic`: Uses the `apksigner` tool to sign an APK and `jarsigner` tool to sign an AAB file.
+      - `apksigner`: Uses the `apksigner` tool to sign the app.
+      - `jarsigner`: Uses the `jarsigner` tool to sign the app.
 - signer_scheme: automatic
   opts:
     title: APK Signature Scheme


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MAJOR* [version update](https://semver.org/)

### Context

The Step currently uses `jarsigner` by default for signing APK files (`use_apk_signer: "false"`), this PR switches to `apksigner` as a default tool for signing APK files.

The change is done by introducing a new step input `signer_tool` which replaces the previous `use_apk_signer` input.
`signer_tool` indicates which tool should be used for signing the app, the available options:
- `automatic` (default value): Uses the `apksigner` tool to sign an APK and `jarsigner` tool to sign an AAB file.
- `apksigner`: Uses the `apksigner` tool to sign the app.
- `jarsigner`: Uses the `jarsigner` tool to sign the app.


### Changes

- `signer_tool` replaces the previous `use_apk_signer` input
- e2e test workflows has been renamed, to better reflect on what they are actually doing:
  - `test_apk` -> `test_apk_signing`
  - `test_apk_debug` -> `test_debug_apk_signing`
  - `test_bundle` -> `test_app_bundle_signing`
  - `_run_collection` -> `_build_app_and_sign_with_keystore_combinations`
  - `utility_test_<test_name>` -> `_sign_with_<test_name>`
  - `_run` -> `_sign_app`
- `_jarsigner_all_tests` and `_apksigner_all_tests` workflows are removed and `_sign_with_jarsigner_with_keystore_with_same_pass` and `_sign_with_apksigner_with_keystore_with_diff_pass` workflows are testing the none default signer tool inputs

